### PR TITLE
Par-Time Alarm Option

### DIFF
--- a/Marble Blast Platinum/platinum/client/defaults.cs
+++ b/Marble Blast Platinum/platinum/client/defaults.cs
@@ -46,6 +46,8 @@ $pref::HelpTriggers = 1;
 $pref::ScreenshotMode = 0;
 $pref::RadarMode = 3;
 
+$pref::parTimeAlarm = true;
+
 $pref::checkLETip = "1";
 $pref::checkTip[1] = "1";
 $pref::FirstRun[$THIS_VERSION] = true;

--- a/Marble Blast Platinum/platinum/client/scripts/optionsGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/optionsGui.cs
@@ -427,53 +427,74 @@ $Options::Type    ["Audio", 3] = "boolean";
 //-----------------------------------------------------------------------------
 // Gameplay
 
-$Options::Name    ["Gameplay", 0] = "fpsCounter";
-$Options::Title   ["Gameplay", 0] = "FPS Counter";
-$Options::Type    ["Gameplay", 0] = "boolean";
-$Options::Name    ["Gameplay", 1] = "freelook";
-$Options::Title   ["Gameplay", 1] = "Free-Look";
-$Options::Type    ["Gameplay", 1] = "boolean";
-$Options::Name    ["Gameplay", 2] = "oobInsults";
-$Options::Title   ["Gameplay", 2] = "OOB Insults";
-$Options::Type    ["Gameplay", 2] = "boolean";
-$Options::Name    ["Gameplay", 3] = "thousandths";
-$Options::Title   ["Gameplay", 3] = "Thousandths";
-$Options::Type    ["Gameplay", 3] = "boolean";
-$Options::Name    ["Gameplay", 4] = "helptriggers";
-$Options::Title   ["Gameplay", 4] = "Help Triggers";
-$Options::Type    ["Gameplay", 4] = "boolean";
-$Options::Name    ["Gameplay", 5] = "screenshotMode";
-$Options::Title   ["Gameplay", 5] = "Show/Hide HUD";
-$Options::Type    ["Gameplay", 5] = "boolean";
-$Options::Name    ["Gameplay", 6] = "fov";
-$Options::Title   ["Gameplay", 6] = "FOV";
-$Options::Ctrl    ["Gameplay", 6] = "slider";
-$Options::Min     ["Gameplay", 6] = 60;
-$Options::Max     ["Gameplay", 6] = 140;
-$Options::Ticks   ["Gameplay", 6] = 80; //Every 1
-$Options::JoyTicks["Gameplay", 6] = 16; //Every 5
-$Options::Name    ["Gameplay", 7] = "maxRadarItems";
-$Options::Title   ["Gameplay", 7] = "Max Radar Items";
-$Options::Ctrl    ["Gameplay", 7] = "slider";
-$Options::Min     ["Gameplay", 7] = 5;
-$Options::Max     ["Gameplay", 7] = 85;
-$Options::Ticks   ["Gameplay", 7] = 80; //Every 1
-$Options::JoyTicks["Gameplay", 7] = 16; //Every 5
-$Options::Name    ["Gameplay", 8] = "alwaysShowSpeedometer";
-$Options::Title   ["Gameplay", 8] = "Always Show Speedometer";
-$Options::Type    ["Gameplay", 8] = "boolean";
-$Options::Name    ["Gameplay", 9] = "powerupsAlwaysOnRadar";
-$Options::Title   ["Gameplay", 9] = "Powerups Always on Radar";
-$Options::Type    ["Gameplay", 9] = "boolean";
-$Options::Name    ["Gameplay", 10] = "powerupTimers";
-$Options::Title   ["Gameplay", 10] = "Powerup Timers";
-$Options::Type    ["Gameplay", 10] = "boolean";
-$Options::Name    ["Gameplay", 11] = "minimalSpectateUI";
-$Options::Title   ["Gameplay", 11] = "(Online) Minimal Spectate UI";
-$Options::Type    ["Gameplay", 11] = "boolean";
-$Options::Name    ["Gameplay", 12] = "spchanges";
-$Options::Title   ["Gameplay", 12] = "Ultra Violet";
-$Options::Type    ["Gameplay", 12] = "boolean";
+$i = -1;
+
+$Options::Name    ["Gameplay", $i++] = "fpsCounter";
+$Options::Title   ["Gameplay", $i] = "FPS Counter";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "freelook";
+$Options::Title   ["Gameplay", $i] = "Free-Look";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "oobInsults";
+$Options::Title   ["Gameplay", $i] = "OOB Insults";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "thousandths";
+$Options::Title   ["Gameplay", $i] = "Thousandths";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "helptriggers";
+$Options::Title   ["Gameplay", $i] = "Help Triggers";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "screenshotMode";
+$Options::Title   ["Gameplay", $i] = "Show/Hide HUD";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+
+$Options::Name    ["Gameplay", $i++] = "fov";
+$Options::Title   ["Gameplay", $i] = "FOV";
+$Options::Ctrl    ["Gameplay", $i] = "slider";
+$Options::Min     ["Gameplay", $i] = 60;
+$Options::Max     ["Gameplay", $i] = 140;
+$Options::Ticks   ["Gameplay", $i] = 80; //Every 1
+$Options::JoyTicks["Gameplay", $i] = 16; //Every 5
+
+
+$Options::Name    ["Gameplay", $i++] = "maxRadarItems";
+$Options::Title   ["Gameplay", $i] = "Max Radar Items";
+$Options::Ctrl    ["Gameplay", $i] = "slider";
+$Options::Min     ["Gameplay", $i] = 5;
+$Options::Max     ["Gameplay", $i] = 85;
+$Options::Ticks   ["Gameplay", $i] = 80; //Every 1
+$Options::JoyTicks["Gameplay", $i] = 16; //Every 5
+
+
+$Options::Name    ["Gameplay", $i++] = "alwaysShowSpeedometer";
+$Options::Title   ["Gameplay", $i] = "Always Show Speedometer";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "powerupsAlwaysOnRadar";
+$Options::Title   ["Gameplay", $i] = "Powerups Always on Radar";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "powerupTimers";
+$Options::Title   ["Gameplay", $i] = "Powerup Timers";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "minimalSpectateUI";
+$Options::Title   ["Gameplay", $i] = "(Online) Minimal Spectate UI";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "spchanges";
+$Options::Title   ["Gameplay", $i] = "Ultra Violet";
+$Options::Type    ["Gameplay", $i] = "boolean";
+
+$Options::Name    ["Gameplay", $i++] = "parTimeAlarm";
+$Options::Title   ["Gameplay", $i] = "Par Time Alarm";
+$Options::Type    ["Gameplay", $i] = "boolean";
 
 Array(ScreenshotModeArray);
 ScreenshotModeArray.addEntry("Show Everything"  TAB 0);
@@ -1459,10 +1480,36 @@ function Opt_spChanges_increase() {
 	$pref::spchanges = !$pref::spchanges;
 	if ($pref::spchanges)
 		MessageBoxOK("The Time Has Come", "With this feature enabled Marble Blast Ultra Levels will now resemble their 360 counterparts even more in Singleplayer!");
-	
 }
 
 //-----------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------
+
+function Opt_parTimeAlarm_getDisplay() {
+	return $pref::parTimeAlarm ? "Enabled" : "Disabled";
+}
+
+function Opt_parTimeAlarm_getValue() {
+	return $pref::parTimeAlarm;
+}
+
+function Opt_parTimeAlarm_decrease() {
+	$pref::parTimeAlarm = !$pref::parTimeAlarm;
+	if ($pref::parTimeAlarm)
+		MessageBoxOK("Stop Ringing!", "With this feature disabled, the game will no longer remind the player if they are about to miss the par time for a level.");
+}
+
+function Opt_parTimeAlarm_increase() {
+	$pref::parTimeAlarm = !$pref::parTimeAlarm;
+	if ($pref::parTimeAlarm)
+		MessageBoxOK("Stop Ringing!", "With this feature disabled, the game will no longer remind the player if they are about to miss the par time for a level.");
+}
+
+//-----------------------------------------------------------------------------
+
+
 
 //-----------------------------------------------------------------------------
 

--- a/Marble Blast Platinum/platinum/client/scripts/playGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/playGui.cs
@@ -743,6 +743,11 @@ function PlayGui::addBonusTime(%this, %dt) {
 }
 
 function PlayGui::refreshRed(%this) {
+
+	//Do not 'refresh red' or play the alarm if the player has disabled the alarm option.
+	if (!$pref::parTimeAlarm)
+		return;
+
 	if ($PlayTimerActive && $InPlayGUI) {
 		if (%this.bonusTime || $Editor::Opened || %this.stopped)
 			$PlayTimerColor = $TimeColor["stopped"];

--- a/README.md
+++ b/README.md
@@ -2,21 +2,5 @@
 
 [![CircleCI](https://circleci.com/gh/The-New-Platinum-Team/BuildScript/tree/circleci-project-setup.svg?style=svg&circle-token=a2188581bd13ccf275c4a3b19c18c2cb55f2f5e2)](https://circleci.com/gh/The-New-Platinum-Team/BuildScript/tree/circleci-project-setup)
 
-This is the main repository for the public release of the game data and scripts for PQ ([old repository here](https://github.com/PlatinumTeam/PlatinumQuest)).
-
-See [MBExtender](https://github.com/RandomityGuy/MBExtender) for the C++ engine modification source code ([old repository here](https://github.com/PlatinumTeam/MBExtender)).
-
-For new developers this should *not* be downloaded from the GitHub website, but cloned with git (or a git client such as VSCode or GitHub Desktop), which has an interface that lets you easily update it and sync your local files to this repository.
-
-## Running
-To run this, you need a copy of the latest game executables. Get them from [PQ Binaries repository](https://github.com/The-New-Platinum-Team/PQBinaries). Copy the files in the platform specific folders to `Marble Blast Platinum` folder. Or, if you want to build the plugins from source, clone and build [MBExtender](https://github.com/The-New-Platinum-Team/MBExtender-Dev) and install it into `Marble Blast Platinum`.
-
-## License
-MIT License for all PQ script files and shaders. See the headers of individual files for further details.
-
-Assets are released here but not under any license. Contact us if you want to use them for your own purposes.
-
-## Contributing
-While there's no formal CLA, your contributions, if included, will also be released here under the MIT license and included in binary form in the game.
-
-There is no linter for Torque Script, but we do have a coding style used throughout the project. Please try to follow it.
+This is a fork repository for the public release of PQ ([repository here](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev)).
+I use this repo in order to make Pull-Requests for the main repo.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,21 @@
 
 [![CircleCI](https://circleci.com/gh/The-New-Platinum-Team/BuildScript/tree/circleci-project-setup.svg?style=svg&circle-token=a2188581bd13ccf275c4a3b19c18c2cb55f2f5e2)](https://circleci.com/gh/The-New-Platinum-Team/BuildScript/tree/circleci-project-setup)
 
-This is a fork repository for the public release of PQ ([repository here](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev)).
-I use this repo in order to make Pull-Requests for the main repo.
+This is the main repository for the public release of the game data and scripts for PQ ([old repository here](https://github.com/PlatinumTeam/PlatinumQuest)).
+
+See [MBExtender](https://github.com/RandomityGuy/MBExtender) for the C++ engine modification source code ([old repository here](https://github.com/PlatinumTeam/MBExtender)).
+
+For new developers this should *not* be downloaded from the GitHub website, but cloned with git (or a git client such as VSCode or GitHub Desktop), which has an interface that lets you easily update it and sync your local files to this repository.
+
+## Running
+To run this, you need a copy of the latest game executables. Get them from [PQ Binaries repository](https://github.com/The-New-Platinum-Team/PQBinaries). Copy the files in the platform specific folders to `Marble Blast Platinum` folder. Or, if you want to build the plugins from source, clone and build [MBExtender](https://github.com/The-New-Platinum-Team/MBExtender-Dev) and install it into `Marble Blast Platinum`.
+
+## License
+MIT License for all PQ script files and shaders. See the headers of individual files for further details.
+
+Assets are released here but not under any license. Contact us if you want to use them for your own purposes.
+
+## Contributing
+While there's no formal CLA, your contributions, if included, will also be released here under the MIT license and included in binary form in the game.
+
+There is no linter for Torque Script, but we do have a coding style used throughout the project. Please try to follow it.


### PR DESCRIPTION
This adds an ability to toggle whether the alarm and reminder for par-time should play if the player is going to go above it.

In addition to that, a small trivial refactor for the Gameplay Options was made to match the Graphics Options to use the incremental setting rather than hardcoding each index.

This video demonstrates the feature in action.

https://user-images.githubusercontent.com/26779639/188369532-6604ebca-1c82-4c84-a143-a20f7863b280.mp4

