### PR TITLE
Let the maximum hunt score predictor be configurable

### DIFF
--- a/Marble Blast Platinum/platinum/client/defaults.cs
+++ b/Marble Blast Platinum/platinum/client/defaults.cs
@@ -45,6 +45,7 @@ $pref::environmentMaps = 0;
 $pref::HelpTriggers = 1;
 $pref::ScreenshotMode = 0;
 $pref::RadarMode = 3;
+$pref::ScorePredictorMaxFactor = 2;
 
 $pref::checkLETip = "1";
 $pref::checkTip[1] = "1";

--- a/Marble Blast Platinum/platinum/client/scripts/modes/hunt.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/modes/hunt.cs
@@ -71,7 +71,12 @@ function updatePredictor() {
 	// vars to look at: MissionInfo.time, PlayGui.currentTime, PlayGui.bonusTime, PlayGui.totalTime, PlayGui.totalBonus
 	// in Hunt, currentTime is basically reversed.
 
-	if ((MissionInfo.time - PlayGui.currentTime) < 10000 || (MissionInfo.awesomeScore && %estimated > MissionInfo.awesomeScore * 2)) { // Don't show if the match hasn't been 10s long, to prevent stupid predictors
+	%predictorMax = 0;
+	if (MissionInfo.awesomeScore) {
+		%predictorMax = MissionInfo.awesomeScore * $pref::ScorePredictorMaxFactor;
+	}
+
+	if ((MissionInfo.time - PlayGui.currentTime) < 10000 || (%predictorMax > 0 && %estimated > %predictorMax)) { // Don't show if the match hasn't been 10s long, to prevent stupid predictors
 		PGScorePredictor.setText(" ");
 	} else {
 		%estimatedColor = "<shadowcolor:0000007f><shadow:1:1>";


### PR DESCRIPTION
Feature request by Mazik. Some hunt levels (particularly Hunting Around) have scores that actually or nearly surpass 2x the awesome score. Currently the score predictor gets disabled when predicting a value that high, so this pull request allows someone to see the predicted score higher than 2x for those hunt levels.

Since this feature is relatively niche (aka, you gotta be reallllly good lol) and the community generally doesn't like adding new toggles, this feature is hidden in the prefs. By changing `$pref::ScorePredictorMaxFactor` (which defaults to 2 to match the previous behavior), you can choose what factor of the awesome score the score predictor will predict to. You can also set this value to 0 and there will be no limit.

This PR does not change the fact that within the first 10 seconds, no score is predicted. Maybe this should also become configurable, because of Hunting Around lol

Here's a quick video demo of the feature: https://youtu.be/gHXsik5wGNA