### PR TITLE
Store respawn inputs in replays

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/default.bind.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/default.bind.cs
@@ -398,7 +398,8 @@ function input_useBlast(%val) {
 
 function input_forceRespawn(%val) {
 	cancel($respawnSchedule);
-	$forceRespawning = %val;
+	if (!%val)
+		$forceCheckpointRespawn = false;
 	if ($Client::GameRunning && %val) {
 		//Update your respawns prefs
 		$pref::LevelRespawns[strreplace($Client::MissionFile, "lbmission", "mission")] ++;
@@ -413,6 +414,7 @@ function input_forceRespawn(%val) {
 			if (LocalClientConnection.checkpointed) {
 				LocalClientConnection.respawnOnCheckpoint();
 				$respawnSchedule = schedule(1000, 0, commandToServer, 'restartLevel');
+				$forceCheckpointRespawn = true;
 			} else {
 				//Rate limit
 				if (getSimTime() - $Game::LastRespawn < 500)

--- a/Marble Blast Platinum/platinum/client/scripts/default.bind.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/default.bind.cs
@@ -398,6 +398,7 @@ function input_useBlast(%val) {
 
 function input_forceRespawn(%val) {
 	cancel($respawnSchedule);
+	$forceRespawning = %val;
 	if ($Client::GameRunning && %val) {
 		//Update your respawns prefs
 		$pref::LevelRespawns[strreplace($Client::MissionFile, "lbmission", "mission")] ++;

--- a/Marble Blast Platinum/platinum/client/scripts/replay.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/replay.cs
@@ -20,7 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-$ReplayVersion = 25;
+$ReplayVersion = 26;
 
 $RecordTag["time"] = 1;
 $RecordTag["position"] = 2;
@@ -493,6 +493,7 @@ function onDemoPlayDone() {
 	jump(0);
 	mouseFire(0);
 	useBlast(0);
+	forceRespawn(0);
 
 	//Exit the mission
 	menuDestroyServer();
@@ -1250,6 +1251,7 @@ function recordWriteInput(%stream) {
 	%flags |= $mvTriggerCount2 << 2;
 	%flags |= $mouseFire       << 3;
 	%flags |= $useBlast        << 4;
+	%flags |= $forceRespawning << 5;
 	%stream.writeRawS32(%flags);
 }
 
@@ -1267,6 +1269,7 @@ function PlaybackFrame::applyInput(%this) {
 	if (%change & 1 << 2) jump      (!!(%flags & 1 << 2));
 	if (%change & 1 << 3) mouseFire (!!(%flags & 1 << 3));
 	if (%change & 1 << 4) useBlast  (!!(%flags & 1 << 4));
+	if (%change & 1 << 5) forceRespawn(!!(%flags & 1 << 5));
 }
 
 //-----------------------------------------------------------------------------

--- a/Marble Blast Platinum/platinum/client/scripts/replay.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/replay.cs
@@ -1251,7 +1251,7 @@ function recordWriteInput(%stream) {
 	%flags |= $mvTriggerCount2 << 2;
 	%flags |= $mouseFire       << 3;
 	%flags |= $useBlast        << 4;
-	%flags |= $forceRespawning << 5;
+	%flags |= $forceCheckpointRespawn << 5;
 	%stream.writeRawS32(%flags);
 }
 

--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -1064,6 +1064,8 @@ function restartLevel(%exitgame) {
 		$MP::Restarting = true;
 	}
 
+	$forceCheckpointRespawn = false;
+
 	$Game::Restarted = true;
 	$Server::SpawnGroups = true;
 	$Game::Running = true;


### PR DESCRIPTION
Fixes replay issues when a player presses the respawn key to go to a checkpoint. See the beginning of PQ WRR, Xedron goes OOB to get the checkpoint, respawns at it, and the camera still acts as is he is OOB: https://www.youtube.com/watch?v=QQlI_XP6F6w

It fixes other issues as well, such as powerups not getting reset properly/gems not respawning/etc.

This does not work retroactively, it only works on newly created replays. ~~Also I want to make sure it doesn't cause problems if the player is holding the respawn button when a run starts (such as, they pressed it while not at a checkpoint). It seems fine, and maybe at the worst case, it plays the respawn sound twice. I still want to make sure it's not causing further problems.~~ Ok, now it should only store checkpoint respawns so there should be no issues there.