### PR TITLE
Fixes from MBP WRR4

### DIFF
--- a/Marble Blast Platinum/platinum/client/defaults.cs
+++ b/Marble Blast Platinum/platinum/client/defaults.cs
@@ -49,6 +49,7 @@ $pref::RadarMode = 3;
 $pref::ScorePredictorMaxFactor = 2;
 $pref::StopRecordingOnMenu = false;
 $pref::NoHolePunching = false;
+$pref::NoFadeIn = false;
 
 $pref::checkLETip = "1";
 $pref::checkTip[1] = "1";

--- a/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
@@ -77,8 +77,10 @@ function onMissionDownloadPhase1(%missionName, %musicTrack) {
 	//MessageHud.close();
 	//cls();
 
-	// this variable is used for the fader effect in playGui::onWake
-	$PlayGuiFader = true;
+	if (!$pref::NoFadeIn) {
+		// this variable is used for the fader effect in playGui::onWake
+		$PlayGuiFader = true;
+	}
 
 	setLoadProgress(0, 1, 0);
 }

--- a/Marble Blast Platinum/platinum/client/scripts/playGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/playGui.cs
@@ -1287,6 +1287,8 @@ function refreshCenterTextCtrl() {
 //-----------------------------------------------------------------------------
 
 function PlayGui::displayGemMessage(%this, %amount, %color) {
+	if ($pref::ScreenshotMode == 2)
+		return;
 	%startCenter = VectorMult(%this.getExtent(), "0.5 0.5");
 	%startPos = VectorSub(%startCenter, "200 50");
 	%this.add(%obj = new GuiMLTextCtrl() {


### PR DESCRIPTION
* Add hidden option to disable the fade in animation. It will not be added to the options menu because the fade in helps hide the level/items popping into existence and it looks ugly without that, but when editing a rampage it's no issue
* Hide time travel "-5" and gem hunt "+1" etc. text messages when the HUD is hidden

See also #134 which brings a feature visible in MBP WRR4 to master

One more thing that we could add is bringing back the RedDragon and PhilsEmpire marbles into TTOTTS. Right now they appear as oddly-reflective MBU marbles. In previous versions of MBP, each marble skin had its own .dts shape and they could put those shapes directly in the level. But now they all share the same shape with separate skins, and unfortunately you can't set the skin of a `TSStatic`. For WRR4 I gave Chris the old marble shapes and a version of the .mis file which had those shapes in place, which worked and looks like the original MBP version of the level. Do we care enough to do this in official PQ, and if so where should we put the shapes and textures?

I also had to make a version of Trapdoor Mania where the trapdoors start down since rrecs don't store that. I don't know if that's been looked into but it'd be cool to support.