### PR TITLE
TT Timer now changes depending on gamemode (cherry-pick to master)

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/playGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/playGui.cs
@@ -32,6 +32,7 @@ function PlayGui::onWake(%this) {
 	// alxStop( ... );
 
 	$PlayGuiGem = true;
+	$PlayGuiTT = true;
 	$InPlayGUI = true;
 	resetCameraFov();
 
@@ -323,6 +324,33 @@ function PlayGui::updateGems(%this, %updateMax) {
 		HUD_ShowGem.setModel(%dts, %skin);
 		Hunt_ShowGem.setModel(%dts, %skin);
 		$PlayGuiGem = false;
+	}
+
+
+	if ($PlayGuiTT) {
+		// PQ gets its own TT
+		if ($currentGame $= "PlatinumQuest") {
+			%skins = "base";
+			%dts = $usermods @ "/data/shapes_pq/gameplay/powerups/timetravel.dts";
+		} else if
+		   ($currentGame $= "Ultra") {
+			%skins = "base";
+			%dts = $usermods @ "/data/shapes_mbu/items/timetravel.dts";
+		} else if
+		   (Sky.materialList $= "platinum/data/skies/sky_day.dml") {
+			%skins = "mbg";
+			%dts = $usermods @ "/data/shapes/items/timetravel.dts";
+		} else {
+			%skins = "base";
+			%dts = $usermods @ "/data/shapes/items/timetravel.dts";
+		}
+
+		// choose it
+		%skin = getWord(%skins, getRandom(0, getWordCount(%skins) - 1));
+		echo("Setting the PlayGUI TT to" SPC %skin);
+
+		PGCountdownTTImage.setModel(%dts, %skin);
+		$PlayGuiTT = false;
 	}
 
 	if (!ClientMode::callback("shouldUpdateGems", true))

--- a/Marble Blast Platinum/platinum/client/ui/playGui.gui
+++ b/Marble Blast Platinum/platinum/client/ui/playGui.gui
@@ -1288,8 +1288,8 @@ new GuiControl(PlayGui) {
 			visible = "0";
 			helpTag = "0";
 
-			new GuiBitmapCtrl(PGCountdownTTImage) {
-				profile = "GuiDefaultProfile";
+			new GuiObjectView(PGCountdownTTImage) {
+				profile = "GuiButtonProfile";
 				horizSizing = "right";
 				vertSizing = "bottom";
 				position = "348 3";
@@ -1297,8 +1297,13 @@ new GuiControl(PlayGui) {
 				minExtent = "8 8";
 				visible = "1";
 				helpTag = "0";
-				bitmap = "./game/countdown/timerTimeTravel";
-				wrap = "0";
+				cameraZRot = "0";
+				forceFOV = "0";
+				skin = "base";
+				cameraRotX = "0";
+				CameraZRotSpeed = "0.001";
+				orbitDistance = "1.39886";
+				autoSize = "1";
 			};
 			new GuiBitmapCtrl(PGCountdownTTFirstDigit) {
 				profile = "GuiDefaultProfile";


### PR DESCRIPTION
This is a commit from 2 years ago by daniel741852 that is on the dev branch, but didn't make it on to master it seems (or was reverted?). It makes TTs different shapes depending on the game mode which makes things look nicer when playing non-PQ themed levels. It also could've been skipped since the PQ TT now seems pretty small. This could potentially be improved with some tuning the values in the GuiObjectView instead of using autoSize.

Making this into a PR instead of directly cherry-picking because I want to make sure there is no intentional reason was withheld from master.

Before:

Game | Image
--- | ---
All | ![image](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev/assets/7307599/dec370ac-ee30-4c74-ba79-7eeac9f234e1)

After:

Game | Image
--- | ---
Gold | ![image](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev/assets/7307599/2440ac94-0a22-420c-a02b-d16ecba25959)
Ultra | ![image](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev/assets/7307599/51fb5da3-d819-4fcd-bb36-84b1c98f704e)
Platinum | ![image](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev/assets/7307599/a0c5bd20-a165-4e0d-9b3f-9a749f6a2eab)
PQ | ![image](https://github.com/The-New-Platinum-Team/PlatinumQuest-Dev/assets/7307599/3de88d60-da11-4563-a0f8-26083822a44e)


