### PR TITLE
Random spawn point in Competitive Mode

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
@@ -444,6 +444,10 @@ function clientCmdShockwave(%mePos, %strength, %myMod, %theyMod) {
 	}
 }
 
+function clientCmdSetSharedSpawnPoint(%index) {
+	$MP::SharedSpawnPointIndex = %index;
+}
+
 function clientCmdServerSetting(%setting, %value) {
 	//TODO: Port these to the other settings
 	switch$ (%setting) {

--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -273,6 +273,8 @@ function onMissionLoaded() {
 		startHeartbeat();
 
 		Time::reset();
+
+		chooseSharedSpawnPoint();
 	}
 
 	MPinitLoops();
@@ -728,6 +730,7 @@ function GameConnection::onClientEnterGame(%this) {
 		if ($Server::Started) {
 			%this.setPregame(false);
 			%this.resetTimer();
+			%this.sendSharedSpawnPoint();
 			%this.setTime($Time::CurrentTime);
 
 			//Spectating...
@@ -1116,11 +1119,14 @@ function restartLevel(%exitgame) {
 	$Server::SpawnGroups = true;
 	$Game::Running = true;
 
+	chooseSharedSpawnPoint();
+
 	// Reset the player back to the last checkpoint
 	onMissionReset();
 	setGameState("start");
 	for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
 		%client = ClientGroup.getObject(%i);
+		%client.sendSharedSpawnPoint();
 		%client.restartLevel();
 		%client.setQuickRespawnStatus(true);
 	}
@@ -1583,4 +1589,15 @@ function getActivePlayerCount() {
 		%players ++;
 	}
 	return %players;
+}
+
+function chooseSharedSpawnPoint() {
+	if (!isObject(SpawnPointSet))
+		return -1;
+
+	%size = SpawnPointSet.getCount();
+	if (%size == 0)
+		return -1;
+
+	$MP::SharedSpawnPointIndex = getRandom(0, %size - 1);
 }

--- a/Marble Blast Platinum/platinum/server/scripts/mp/gameConnection.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/mp/gameConnection.cs
@@ -37,7 +37,6 @@ function GameConnection::stopTimer(%this) {
 function GameConnection::resetTimer(%this) {
 	commandToClient(%this, 'resetTimer');
 }
-
 function GameConnection::setTimeStopped(%this, %stopped) {
 	if (%this.fake)
 		return;
@@ -221,6 +220,13 @@ function GameConnection::setMovementKeysEnabled(%this, %enabled) {
 	commandToClient(%this, 'EnableMovementKeys', %enabled);
 }
 
+function GameConnection::sendSharedSpawnPoint(%this) {
+	if ($MP::SharedSpawnPointIndex $= "") {
+		chooseSharedSpawnPoint();
+	}
+	commandToClient(%this, 'setSharedSpawnPoint', $MP::SharedSpawnPointIndex);
+}
+
 function GameConnection::setWhiteOut(%this, %whiteout) {
 	%this.player.setWhiteOut(max(%this.player.getWhiteOut(), %whiteout));
 }
@@ -396,9 +402,11 @@ function GameConnection::getSharedSpawnTrigger(%this) {
 	if (($Sim::Time - %this.lastSpawnTime) > 4)
 		%this.lastSpawnTrigger = "";
 
-	// Always gets the first available spawn trigger
-	// Would be nice for the server to randomly pick one and sync to all players, but this will work for now.
-	return SpawnPointSet.getObject(0);
+	if ($MP::SharedSpawnPointIndex $= "") {
+		// We don't have a value here...
+		$MP::SharedSpawnPointIndex = 0;
+	}
+	return SpawnPointSet.getObject($MP::SharedSpawnPointIndex);
 }
 
 function GameConnection::pointToNearestGem(%this) {


### PR DESCRIPTION
Pioneered by @ShadowVisions, this lets the server choose a random spawn point in competitive which gets synced to the clients. This makes it so the first spawn point isn't always the one that's chosen