### PR TITLE
Bonus + Official tabs to the stats and leaderboard pages

### DIFF
--- a/Marble Blast Platinum/platinum/client/ui/lb/LBScoresDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/lb/LBScoresDlg.gui
@@ -35,17 +35,21 @@ new GuiBitmapCtrl(LBScoresDlg) {
 	_guiSize = "800 600";
 	pageSize = "15";
 	categoryMap["General"]       = "rating_general";
+	categoryMap["Official"]      = "rating_official";
 	categoryMap["Gold"]          = "rating_mbg";
 	categoryMap["Platinum"]      = "rating_mbp";
 	categoryMap["Ultra"]         = "rating_mbu";
 	categoryMap["PlatinumQuest"] = "rating_pq";
+	categoryMap["Bonus"]         = "rating_bonus";
 	categoryMap["Custom"]        = "rating_custom";
 	categoryMap["Multiplayer"]   = "rating_mp";
 	categoryMap["rating_general"] = "General";
+	categoryMap["rating_official"]= "Official";
 	categoryMap["rating_mbg"]     = "Gold";
 	categoryMap["rating_mbp"]     = "Platinum";
 	categoryMap["rating_mbu"]     = "Ultra";
 	categoryMap["rating_pq"]      = "PlatinumQuest";
+	categoryMap["rating_bonus"]   = "Bonus";
 	categoryMap["rating_custom"]  = "Custom";
 	categoryMap["rating_mp"]      = "Multiplayer";
 	defaultControl = "LB_GeneralSingleplayerCategory";
@@ -64,7 +68,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 		horizSizing = "center";
 		vertSizing = "center";
 		position = "175 43";
-		extent = "450 514";
+		extent = "450 550";
 		minExtent = "61 61";
 		visible = "1";
 		helpTag = "0";
@@ -105,7 +109,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			horizSizing = "right";
 			vertSizing = "top";
 			position = "224 370";
-			extent = "199 47";
+			extent = "198 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBScoresDlg.selectGame(\"Multiplayer\");";
@@ -116,14 +120,14 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
 			controlLeft = "LB_GeneralSingleplayerCategory";
-			controlDown = "LB_GeneralCustomCategory";
+			controlDown = "LB_GeneralOfficialCategory";
 		};
 		new GuiBorderButtonCtrl(LB_GeneralGeneralCategory) {
 			profile = "PQButtonPillSmallLeftProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "27 406";
-			extent = "81 47";
+			position = "98 406";
+			extent = "126 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBScoresDlg.selectCategory(\"General\");";
@@ -134,26 +138,44 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
 			controlUp = "LB_GeneralSingleplayerCategory";
-			controlRight = "LB_GeneralGoldCategory";
-			controlDown = "LB_GeneralPrev";
+			controlRight = "LB_GeneralOfficialCategory";
+			controlDown = "LB_GeneralUltraCategory";
 		};
-		new GuiBorderButtonCtrl(LB_GeneralGoldCategory) {
-			profile = "PQButtonPillSmallCenterProfile";
+		new GuiBorderButtonCtrl(LB_GeneralOfficialCategory) {
+			profile = "PQButtonPillSmallRightProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "108 406";
-			extent = "51 47";
+			position = "224 406";
+			extent = "126 47";
 			minExtent = "8 8";
 			visible = "1";
-			command = "LBScoresDlg.selectCategory(\"Gold\");";
+			command = "LBScoresDlg.selectCategory(\"Official\");";
 			helpTag = "0";
-			text = "Gold";
+			text = "Official  ";
 			groupNum = "1";
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralSingleplayerCategory";
+			controlUp = "LB_GeneralMultiplayerCategory";
 			controlLeft = "LB_GeneralGeneralCategory";
+			controlDown = "LB_GeneralPlatinumQuestCategory";
+		};
+		new GuiBorderButtonCtrl(LB_GeneralGoldCategory) {
+			profile = "PQButtonPillSmallLeftProfile";
+			horizSizing = "right";
+			vertSizing = "top";
+			position = "27 442";
+			extent = "59 47";
+			minExtent = "8 8";
+			visible = "1";
+			command = "LBScoresDlg.selectCategory(\"Gold\");";
+			helpTag = "0";
+			text = "  Gold";
+			groupNum = "1";
+			buttonType = "RadioButton";
+			repeatPeriod = "450";
+			repeatDecay = "0.958";
+			controlUp = "LB_GeneralGeneralCategory";
 			controlRight = "LB_GeneralPlatinumCategory";
 			controlDown = "LB_GeneralPrev";
 		};
@@ -161,7 +183,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "159 406";
+			position = "86 442";
 			extent = "81 47";
 			minExtent = "8 8";
 			visible = "1";
@@ -172,17 +194,17 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralSingleplayerCategory";
+			controlUp = "LB_GeneralGeneralCategory";
 			controlLeft = "LB_GeneralGoldCategory";
 			controlRight = "LB_GeneralUltraCategory";
-			controlDown = "LB_GeneralClose";
+			controlDown = "LB_GeneralPrev";
 		};
 		new GuiBorderButtonCtrl(LB_GeneralUltraCategory) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "240 406";
-			extent = "52 47";
+			position = "167 442";
+			extent = "57 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBScoresDlg.selectCategory(\"Ultra\");";
@@ -192,7 +214,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralMultiplayerCategory";
+			controlUp = "LB_GeneralGeneralCategory";
 			controlLeft = "LB_GeneralPlatinumCategory";
 			controlRight = "LB_GeneralPlatinumQuestCategory";
 			controlDown = "LB_GeneralClose";
@@ -201,8 +223,8 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "292 406";
-			extent = "46 47";
+			position = "224 442";
+			extent = "51 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBScoresDlg.selectCategory(\"PlatinumQuest\");";
@@ -212,8 +234,28 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralMultiplayerCategory";
+			controlUp = "LB_GeneralOfficialCategory";
 			controlLeft = "LB_GeneralUltraCategory";
+			controlRight = "LB_GeneralBonusCategory";
+			controlDown = "LB_GeneralClose";
+		};
+		new GuiBorderButtonCtrl(LB_GeneralBonusCategory) {
+			profile = "PQButtonPillSmallCenterProfile";
+			horizSizing = "right";
+			vertSizing = "top";
+			position = "275 442";
+			extent = "63 47";
+			minExtent = "8 8";
+			visible = "1";
+			command = "LBScoresDlg.selectCategory(\"Bonus\");";
+			helpTag = "0";
+			text = "Bonus";
+			groupNum = "1";
+			buttonType = "RadioButton";
+			repeatPeriod = "450";
+			repeatDecay = "0.958";
+			controlUp = "LB_GeneralOfficialCategory";
+			controlLeft = "LB_GeneralPlatinumQuestCategory";
 			controlRight = "LB_GeneralCustomCategory";
 			controlDown = "LB_GeneralNext";
 		};
@@ -221,8 +263,8 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			profile = "PQButtonPillSmallRightProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "338 406";
-			extent = "85 47";
+			position = "338 442";
+			extent = "84 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBScoresDlg.selectCategory(\"Custom\");";
@@ -232,15 +274,15 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralMultiplayerCategory";
-			controlLeft = "LB_GeneralPlatinumQuestCategory";
+			controlUp = "LB_GeneralOfficialCategory";
+			controlLeft = "LB_GeneralBonusCategory";
 			controlDown = "LB_GeneralNext";
 		};
 		new GuiBorderButtonCtrl(LB_GeneralPrev) {
 			profile = "PQButtonPillLeftProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "84 442";
+			position = "84 478";
 			extent = "94 45";
 			minExtent = "8 8";
 			visible = "1";
@@ -251,14 +293,14 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RepeaterButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralGoldCategory";
+			controlUp = "LB_GeneralPlatinumCategory";
 			controlRight = "LB_GeneralClose";
 		};
 		new GuiBorderButtonCtrl(LB_GeneralClose) {
 			profile = "PQButtonPillCenterProfile";
 			horizSizing = "center";
 			vertSizing = "top";
-			position = "178 442";
+			position = "178 478";
 			extent = "94 45";
 			minExtent = "8 8";
 			visible = "1";
@@ -269,7 +311,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "PushButton";
 			repeatPeriod = "1000";
 			repeatDecay = "1";
-			controlUp = "LB_GeneralPlatinumCategory";
+			controlUp = "LB_GeneralUltraCategory";
 			controlLeft = "LB_GeneralPrev";
 			controlRight = "LB_GeneralNext";
 		};
@@ -277,7 +319,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			profile = "PQButtonPillRightProfile";
 			horizSizing = "left";
 			vertSizing = "top";
-			position = "272 442";
+			position = "272 478";
 			extent = "94 45";
 			minExtent = "8 8";
 			visible = "1";
@@ -288,7 +330,7 @@ new GuiBitmapCtrl(LBScoresDlg) {
 			buttonType = "RepeaterButton";
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
-			controlUp = "LB_GeneralPlatinumQuestCategory";
+			controlUp = "LB_GeneralBonusCategory";
 			controlLeft = "LB_GeneralClose";
 		};
 	};
@@ -366,25 +408,30 @@ function LBScoresDlg::updatePage(%this) {
 	if (%this.page <= 0) {
 		%this.page = 0;
 		LB_GeneralPrev.setActive(false);
-	} else if (%this.page >= mFloor(%category.display.getSize() / %this.pageSize)) {
+	}
+	if (%this.page >= mFloor(%category.display.getSize() / %this.pageSize)) {
 		%this.page = mFloor(%category.display.getSize() / %this.pageSize);
 		LB_GeneralNext.setActive(false);
 	}
 
 	LB_GeneralGeneralCategory.setActive(%this.game $= "SinglePlayer");
+	LB_GeneralOfficialCategory.setActive(%this.game $= "SinglePlayer");
 	LB_GeneralPlatinumCategory.setActive(%this.game $= "SinglePlayer");
 	LB_GeneralGoldCategory.setActive(%this.game $= "SinglePlayer");
 	LB_GeneralUltraCategory.setActive(%this.game $= "SinglePlayer");
 	LB_GeneralPlatinumQuestCategory.setActive(%this.game $= "SinglePlayer");
+	LB_GeneralBonusCategory.setActive(%this.game $= "SinglePlayer");
 	LB_GeneralCustomCategory.setActive(%this.game $= "SinglePlayer");
 
 	LB_GeneralSingleplayerCategory.setValue(%this.game $= "SinglePlayer");
 	LB_GeneralMultiplayerCategory.setValue(%this.game $= "Multiplayer");
 	LB_GeneralGeneralCategory.setValue(%this.category $= "General");
+	LB_GeneralOfficialCategory.setValue(%this.category $= "Official");
 	LB_GeneralGoldCategory.setValue(%this.category $= "Gold");
 	LB_GeneralPlatinumCategory.setValue(%this.category $= "Platinum");
 	LB_GeneralUltraCategory.setValue(%this.category $= "Ultra");
 	LB_GeneralPlatinumQuestCategory.setValue(%this.category $= "PlatinumQuest");
+	LB_GeneralBonusCategory.setValue(%this.category $= "Bonus");
 	LB_GeneralCustomCategory.setValue(%this.category $= "Custom");
 
 	ControllerGui.updateButtons();
@@ -403,6 +450,8 @@ function LBScoresDlg::showPage(%this) {
 	%title = "";
 	if (%this.category $= "General")
 		%title = "General Rankings";
+	if (%this.category $= "Official")
+		%title = "Official Levels";
 	if (%this.category $= "Platinum")
 		%title = "Marble Blast Platinum";
 	if (%this.category $= "Gold")
@@ -411,6 +460,8 @@ function LBScoresDlg::showPage(%this) {
 		%title = "Marble Blast Ultra";
 	if (%this.category $= "PlatinumQuest")
 		%title = "PlatinumQuest";
+	if (%this.category $= "Bonus")
+		%title = "Bonus Levels";
 	if (%this.category $= "Custom")
 		%title = "Custom Levels";
 	if (%this.game $= "Multiplayer")

--- a/Marble Blast Platinum/platinum/client/ui/lb/LBStatsDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/lb/LBStatsDlg.gui
@@ -49,7 +49,7 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 		horizSizing = "center";
 		vertSizing = "center";
 		position = "178 61";
-		extent = "443 477";
+		extent = "443 513";
 		minExtent = "61 61";
 		visible = "1";
 		helpTag = "0";
@@ -101,8 +101,8 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			profile = "PQButtonPillSmallLeftProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "27 356";
-			extent = "83 47";
+			position = "98 356";
+			extent = "123 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBStatsDlg.selectCategory(\"General\");";
@@ -113,17 +113,33 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
 		};
-		new GuiBorderButtonCtrl(LB_StatsGoldCategory) {
-			profile = "PQButtonPillSmallCenterProfile";
+		new GuiBorderButtonCtrl(LB_StatsOfficialCategory) {
+			profile = "PQButtonPillSmallRightProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "110 356";
-			extent = "48 47";
+			position = "221 356";
+			extent = "123 47";
+			minExtent = "8 8";
+			visible = "1";
+			command = "LBStatsDlg.selectCategory(\"Official\");";
+			helpTag = "0";
+			text = "Official  ";
+			groupNum = "1";
+			buttonType = "RadioButton";
+			repeatPeriod = "450";
+			repeatDecay = "0.958";
+		};
+		new GuiBorderButtonCtrl(LB_StatsGoldCategory) {
+			profile = "PQButtonPillSmallLeftProfile";
+			horizSizing = "right";
+			vertSizing = "top";
+			position = "27 392";
+			extent = "58 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBStatsDlg.selectCategory(\"Gold\");";
 			helpTag = "0";
-			text = "Gold";
+			text = "  Gold";
 			groupNum = "1";
 			buttonType = "RadioButton";
 			repeatPeriod = "450";
@@ -133,8 +149,8 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "158 356";
-			extent = "81 47";
+			position = "85 392";
+			extent = "80 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBStatsDlg.selectCategory(\"Platinum\");";
@@ -149,8 +165,8 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "239 356";
-			extent = "51 47";
+			position = "165 392";
+			extent = "56 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBStatsDlg.selectCategory(\"Ultra\");";
@@ -165,8 +181,8 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			profile = "PQButtonPillSmallCenterProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "290 356";
-			extent = "44 47";
+			position = "221 392";
+			extent = "50 47";
 			minExtent = "8 8";
 			visible = "1";
 			command = "LBStatsDlg.selectCategory(\"PlatinumQuest\");";
@@ -177,11 +193,27 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			repeatPeriod = "450";
 			repeatDecay = "0.958";
 		};
+		new GuiBorderButtonCtrl(LB_StatsBonusCategory) {
+			profile = "PQButtonPillSmallCenterProfile";
+			horizSizing = "right";
+			vertSizing = "top";
+			position = "271 392";
+			extent = "62 47";
+			minExtent = "8 8";
+			visible = "1";
+			command = "LBStatsDlg.selectCategory(\"Bonus\");";
+			helpTag = "0";
+			text = "Bonus";
+			groupNum = "1";
+			buttonType = "RadioButton";
+			repeatPeriod = "450";
+			repeatDecay = "0.958";
+		};
 		new GuiBorderButtonCtrl(LB_StatsCustomCategory) {
 			profile = "PQButtonPillSmallRightProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "334 356";
+			position = "333 392";
 			extent = "82 47";
 			minExtent = "8 8";
 			visible = "1";
@@ -197,7 +229,7 @@ new GuiChunkedBitmapCtrl(LBStatsDlg) {
 			profile = "PQButtonProfile";
 			horizSizing = "center";
 			vertSizing = "top";
-			position = "174 403";
+			position = "174 439";
 			extent = "94 47";
 			minExtent = "8 8";
 			visible = "1";
@@ -217,10 +249,12 @@ function LBStatsDlg::show(%this, %user) {
 	%this.user = %user;
 	%this.category = "General";
 	LB_StatsGeneralCategory.setValue(1);
+	LB_StatsOfficialCategory.setValue(0);
 	LB_StatsGoldCategory.setValue(0);
 	LB_StatsPlatinumCategory.setValue(0);
 	LB_StatsUltraCategory.setValue(0);
 	LB_StatsPlatinumQuestCategory.setValue(0);
+	LB_StatsBonusCategory.setValue(0);
 	LB_StatsCustomCategory.setValue(0);
 
 	statsGetPlayerStats(%user);
@@ -239,22 +273,28 @@ function LBStatsDlg::prevCategory(%this) {
 	switch$ (%this.category) {
 	case "General":
 		%this.selectCategory("Custom");
-	case "Gold":
+	case "Official":
 		%this.selectCategory("General");
+	case "Gold":
+		%this.selectCategory("Official");
 	case "Platinum":
 		%this.selectCategory("Gold");
 	case "Ultra":
 		%this.selectCategory("Platinum");
 	case "PlatinumQuest":
 		%this.selectCategory("Ultra");
-	case "Custom":
+	case "Bonus":
 		%this.selectCategory("PlatinumQuest");
+	case "Custom":
+		%this.selectCategory("Bonus");
 	}
 }
 
 function LBStatsDlg::nextCategory(%this) {
 	switch$ (%this.category) {
 	case "General":
+		%this.selectCategory("Official");
+	case "Official":
 		%this.selectCategory("Gold");
 	case "Gold":
 		%this.selectCategory("Platinum");
@@ -263,6 +303,8 @@ function LBStatsDlg::nextCategory(%this) {
 	case "Ultra":
 		%this.selectCategory("PlatinumQuest");
 	case "PlatinumQuest":
+		%this.selectCategory("Bonus");
+	case "Bonus":
 		%this.selectCategory("Custom");
 	case "Custom":
 		%this.selectCategory("General");
@@ -273,10 +315,12 @@ function LBStatsDlg::selectCategory(%this, %category) {
 	%this.category = %category;
 
 	LB_StatsGeneralCategory.setValue(%category $= "General");
+	LB_StatsOfficialCategory.setValue(%category $= "Official");
 	LB_StatsGoldCategory.setValue(%category $= "Gold");
 	LB_StatsPlatinumCategory.setValue(%category $= "Platinum");
 	LB_StatsUltraCategory.setValue(%category $= "Ultra");
 	LB_StatsPlatinumQuestCategory.setValue(%category $= "PlatinumQuest");
+	LB_StatsBonusCategory.setValue(%category $= "Bonus");
 	LB_StatsCustomCategory.setValue(%category $= "Custom");
 
 	%this.update();
@@ -300,6 +344,13 @@ function LBStatsDlg::update(%this) {
 		%text = %text NL "<just:left>Total Time Travel: <just:right>" @ formatTimeHoursMs(%stats.general.total_bonus);
 		%text = %text NL "<just:left>Total Time: <just:right>" @ formatTimeHoursMs(%stats.general.total_time);
 		%text = %text NL "<just:left>Grand Total: <just:right>" @ formatTimeHoursMs(%stats.general.grand_total);
+	} else if (%this.category $= "Official") {
+		// Official stats
+		// This page is kinda sad... should we put a game rating breakdown here?
+		%text = "<bold:24><just:center>Official Levels Statistics";
+		%text = %text @ "<font:18>\n";
+		%text = %text NL "<just:left>Official Rating: <just:right>" @ formatScore(%stats.official.rating);
+		%text = %text NL "<just:left>Official Ranking: <just:right>" @ formatScore(%stats.official.rank);
 	} else {
 		//Game-specific stats
 		%gameId = %stats.gameIds.getFieldValue(%this.category);
@@ -347,7 +398,7 @@ function LBStatsDlg::update(%this) {
 			        @ mFloor(%game.completion.awesome_count) @ " / " @ mFloor(%game.totals.total_awesomes) @ " (" @ %percent @ ")";
 		}
 		//Easter Eggs
-		if (%game.has_easter_eggs) {
+		if (%game.has_easter_eggs && (%game.totals.total_eggs > 0)) {
 			%percent = mFloor(100 * (%game.completion.egg_count / %game.totals.total_eggs)) @ "%";
 			%text = %text NL "<just:left>Total " @ %game.easter_egg_name @ "s: <just:right>"
 			        @ mFloor(%game.completion.egg_count) @ " / " @ mFloor(%game.totals.total_eggs) @ " (" @ %percent @ ")";

--- a/Marble Blast Platinum/platinum/client/ui/lb/LBUserDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/lb/LBUserDlg.gui
@@ -489,6 +489,8 @@ function LBUserDlg::updateInfo(%this) {
 		%text = %text NL "<tab:90,135>";
 		%text = %text NL  "<just:left><bold:18>Overall Rank: <font:18>\t" @ formatScore(%stats.ranking.rating_general);
 		%text = %text TAB "<bold:18>Total Rating: <font:18><just:right>"  @ formatScore(%stats.rating.rating_general);
+		%text = %text NL  "<just:left><bold:18>Official Rank: <font:18>\t" @ formatScore(%stats.ranking.rating_official);
+		%text = %text TAB "<bold:18>Official Rating: <font:18><just:right>"  @ formatScore(%stats.rating.rating_official);
 		%text = %text NL  "<just:left><bold:18>Rank MBG: <font:18>\t"     @ formatScore(%stats.ranking.rating_mbg);
 		%text = %text TAB "<bold:18>Rating MBG: <font:18><just:right>"    @ formatScore(%stats.rating.rating_mbg);
 		%text = %text NL  "<just:left><bold:18>Rank MBP: <font:18>\t"     @ formatScore(%stats.ranking.rating_mbp);
@@ -497,6 +499,8 @@ function LBUserDlg::updateInfo(%this) {
 		%text = %text TAB "<bold:18>Rating MBU: <font:18><just:right>"    @ formatScore(%stats.rating.rating_mbu);
 		%text = %text NL  "<just:left><bold:18>Rank PQ: <font:18>\t"      @ formatScore(%stats.ranking.rating_pq);
 		%text = %text TAB "<bold:18>Rating PQ: <font:18><just:right>"     @ formatScore(%stats.rating.rating_pq);
+		%text = %text NL  "<just:left><bold:18>Rank Bonus: <font:18>\t"      @ formatScore(%stats.ranking.rating_bonus);
+		%text = %text TAB "<bold:18>Rating Bonus: <font:18><just:right>"     @ formatScore(%stats.rating.rating_bonus);
 		%text = %text NL  "<just:left><bold:18>Rank Custom: <font:18>\t"  @ formatScore(%stats.ranking.rating_custom);
 		%text = %text TAB "<bold:18>Rating Custom: <font:18><just:right>" @ formatScore(%stats.rating.rating_custom);
 		%text = %text NL "<tab:90,135>";


### PR DESCRIPTION
I had to add a new row of buttons since both Bonus and Official weren't going to fit, so General and Official get bigger buttons on their own rows now.
![image](https://github.com/user-attachments/assets/42e6f53b-2aa7-4e01-b4d1-93d42d18039f)
![image](https://github.com/user-attachments/assets/795db52c-ac68-47f0-aa83-a744eec87523)
