### PR TITLE
Level Fade-In Animation Now Always Plays When Loading Into a Level

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
@@ -78,8 +78,7 @@ function onMissionDownloadPhase1(%missionName, %musicTrack) {
 	//cls();
 
 	if (!$pref::NoFadeIn) {
-		// this variable is used for the fader effect in playGui::onWake
-		$PlayGuiFader = true;
+		$PlayGuiFader = true; // this variable is used for the fader effect in playGui::onWake
 	}
 
 	setLoadProgress(0, 1, 0);

--- a/Marble Blast Platinum/platinum/client/ui/playMissionGui.gui
+++ b/Marble Blast Platinum/platinum/client/ui/playMissionGui.gui
@@ -3340,6 +3340,9 @@ function PlayMissionGui::play(%this) {
 			return;
 		}
 		if ($Menu::Loaded) {
+			if (!$pref::NoFadeIn) {
+				$PlayGuiFader = true; // this variable is used for the fader effect in playGui::onWake
+			}
 			menuPlay();
 		} else {
 			%this.loadMission();


### PR DESCRIPTION
playMissionGui.play() now sets $PlayGuiFader to true now as well alongside missiondownload.cs's onMissionDownloadPhase1()

CLOSES #149 