### PR TITLE
Fix Level Fade-In Animation Being Delayed by Screenshot Mode

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/playGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/playGui.cs
@@ -144,8 +144,7 @@ function PlayGui::onWake(%this) {
 	useScriptCameraTransform(false);
 
 	// update the fader status
-	// this variable is set true in missiondownload.cs
-	PG_Fader.setVisible($PlayGuiFader);
+	PG_Fader.setVisible($PlayGuiFader && ($pref::ScreenshotMode < 2)); //Check screenshot mode now since disabling it later will make this show up late
 	$PlayGuiFader = false;
 
 	$Game::PlayingStart = $Sim::Time;


### PR DESCRIPTION
playGui now checks to make sure the UI isn't hidden before initializing the fade-in animation

CLOSES #150 