### PR TITLE
Fix Automatic Audio Swap Not Working Properly for PQ Levels

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/missiondownload.cs
@@ -148,7 +148,7 @@ function onPhase3Complete() {
 		} else if ((MissionInfo.game $= "Platinum") || ((Sky.materialList $= "platinum/data/skies/Beginner/Beginner_Sky.dml") || (Sky.materialList $= "platinum/data/skies/Intermediate/Intermediate_Sky.dml") || (Sky.materialList $= "platinum/data/skies/Advanced/Advanced_Sky.dml") || (Sky.materialList $= "platinum/data/skies/Expert/Expert_Sky.dml") || (Sky.materialList $= "platinum/data/skies/Bonus/Bonus_Sky.dml") || (Sky.materialList $= "platinum/data/skies/SpaceStation/SpaceStationSky.dml"))) {
 			loadAudioPack(mbp);
 		} else if ((MissionInfo.game $= "PlatinumQuest") || (MissionInfo.modification $= "PlatinumQuest")) {
-			loadAudioPack($pref::Audio::AudioPack);
+			loadAudioPack();
 		}
 	} else if (!$optimizedaudio) {
 		$optimizedaudio = true;


### PR DESCRIPTION
The code literally _specified_ that it should use the _chosen_ audio pack instead of the actual default PQ one? Who tf wrote this? I blame Daniel.

CLOSES #151 