### PR TITLE
Added triggers to end of cannon on Lost Islands

### DIFF
--- a/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/LostIslands.mcs
@@ -1264,7 +1264,7 @@ new SimGroup(MissionGroup) {
 			z = "none";
 	};
 	new Trigger(nojump) {
-		position = "-143.5 31.1875 -41.25";
+		position = "-143.5 30.7 -41.25";
 		rotation = "1 0 0 0";
 		scale = "1 0.25 1";
 		dataBlock = "MarblePhysModTrigger";

--- a/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/LostIslands.mcs
@@ -1252,6 +1252,27 @@ new SimGroup(MissionGroup) {
 			Smooth = "1";
 			Time = "500";
 	};
+	new Trigger() {
+		position = "-138 31 -45.75";
+		rotation = "1 0 0 0";
+		scale = "7 1 7";
+		dataBlock = "AlignmentTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			alwaysOn = "1";
+			x = "none";
+			y = "trigger";
+			z = "none";
+	};
+	new Trigger(nojump) {
+		position = "-143.5 31.1875 -41.25";
+		rotation = "1 0 0 0";
+		scale = "1 0.25 1";
+		dataBlock = "MarblePhysModTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			marbleAttribute0 = "jumpImpulse";
+			noEmitters = "1";
+			value0 = "0";
+	};
 };
 }
 //--- MISSION END ---

--- a/Marble Blast Platinum/platinum/data/missions_pq/advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/missions_pq/advanced/LostIslands.mcs
@@ -1264,7 +1264,7 @@ new SimGroup(MissionGroup) {
 			z = "none";
 	};
 	new Trigger(nojump) {
-		position = "-143.5 31.1875 -41.25";
+		position = "-143.5 30.7 -41.25";
 		rotation = "1 0 0 0";
 		scale = "1 0.25 1";
 		dataBlock = "MarblePhysModTrigger";

--- a/Marble Blast Platinum/platinum/data/missions_pq/advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/missions_pq/advanced/LostIslands.mcs
@@ -1252,6 +1252,27 @@ new SimGroup(MissionGroup) {
 			Smooth = "1";
 			Time = "500";
 	};
+	new Trigger() {
+		position = "-138 31 -45.75";
+		rotation = "1 0 0 0";
+		scale = "7 1 7";
+		dataBlock = "AlignmentTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			alwaysOn = "1";
+			x = "none";
+			y = "trigger";
+			z = "none";
+	};
+	new Trigger(nojump) {
+		position = "-143.5 31.1875 -41.25";
+		rotation = "1 0 0 0";
+		scale = "1 0.25 1";
+		dataBlock = "MarblePhysModTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			marbleAttribute0 = "jumpImpulse";
+			noEmitters = "1";
+			value0 = "0";
+	};
 };
 }
 //--- MISSION END ---

--- a/Marble Blast Platinum/platinum/data/multiplayer/coop/pq_advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/multiplayer/coop/pq_advanced/LostIslands.mcs
@@ -1243,6 +1243,27 @@ new SimGroup(MissionGroup) {
 			Smooth = "1";
 			Time = "500";
 	};
+	new Trigger() {
+		position = "-138 31 -45.75";
+		rotation = "1 0 0 0";
+		scale = "7 1 7";
+		dataBlock = "AlignmentTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			alwaysOn = "1";
+			x = "none";
+			y = "trigger";
+			z = "none";
+	};
+	new Trigger(nojump) {
+		position = "-143.5 31.1875 -41.25";
+		rotation = "1 0 0 0";
+		scale = "1 0.25 1";
+		dataBlock = "MarblePhysModTrigger";
+		polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
+			marbleAttribute0 = "jumpImpulse";
+			noEmitters = "1";
+			value0 = "0";
+	};
 };
 }
 //--- MISSION END ---

--- a/Marble Blast Platinum/platinum/data/multiplayer/coop/pq_advanced/LostIslands.mcs
+++ b/Marble Blast Platinum/platinum/data/multiplayer/coop/pq_advanced/LostIslands.mcs
@@ -1255,7 +1255,7 @@ new SimGroup(MissionGroup) {
 			z = "none";
 	};
 	new Trigger(nojump) {
-		position = "-143.5 31.1875 -41.25";
+		position = "-143.5 30.7 -41.25";
 		rotation = "1 0 0 0";
 		scale = "1 0.25 1";
 		dataBlock = "MarblePhysModTrigger";


### PR DESCRIPTION
* Added a new alignment trigger surrounding the right side of the section after the cannon, with the fade platforms on the bottom
* Added a hidden physmod trigger inside the water to prevent jumping into the foreground

CLOSES #166 