### PR TITLE
Server Address Now Requires a Click to Show

### DIFF
--- a/Marble Blast Platinum/platinum/client/ui/mp/MPServerDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/mp/MPServerDlg.gui
@@ -150,7 +150,7 @@ new GuiBitmapCtrl(MPServerDlg) {
 			profile = "GuiMLTextProfile";
 			horizSizing = "right";
 			vertSizing = "top";
-			position = "26 338";
+			position = "26 337";
 			extent = "197 21";
 			minExtent = "8 8";
 			visible = "1";


### PR DESCRIPTION
Server Settings now hides the IP of the server until you click a button (plus an additional confirmation), to avoid accidentally including your IP in recordings.

CLOSES #30 