### PR TITLE
$Server::Loading and $Server::Loaded Are Now Set Upon Level Load

### DIFF
--- a/Marble Blast Platinum/platinum/server/scripts/mp/server.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/mp/server.cs
@@ -46,7 +46,9 @@ function serverStartGame() {
 			%client.forceSpectate = true;
 	}
 
-	$Server::Started = true;
+	$Server::Loading  = false;
+	$Server::Loaded   = true;
+	$Server::Started  = true;
 	$Game::FirstSpawn = true;
 
 	updatePlayerlist();


### PR DESCRIPTION
Starting a level now ensures that $Server::Loading is set to false (since loading must be done), and $Server::Loaded is set to true (since the level must be loaded)

CLOSES #174 