### PR TITLE
Vice End Screen Enhancements

### DIFF
--- a/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/Vice.mcs
+++ b/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/Vice.mcs
@@ -86,7 +86,7 @@ if (!$Server::Dedicated) {
 				extent = "94 45";
 				minExtent = "8 8";
 				visible = "1";
-				command = "VVNameDlg.dosave();";
+				command = "VVNameDlg.trysave();";
 				helpTag = "0";
 				text = "Save";
 				groupNum = "-1";
@@ -166,13 +166,16 @@ function VVNameDlg::onWake(%this) {
 	%this.checkName();
 }
 
-function VVNameDlg::dosave(%this) {
+function VVNameDlg::trysave(%this) {
 	%filename = $usermods @ "/data/state/vv" @ VVND_Name.getValue() @ ".txt";
 	if (isFile(%filename)) {
-		MessageBoxOk("Error", "That run save already exists.");
+		MessageBoxYesNo("Error", "A saved run with that name already exists. Would you like to overwrite it?", "VVNameDlg.dosave(\"" @ %filename @ "\");");
 		return;
-	}
+	} else
+		%this.dosave(%filename);
+}
 
+function VVNameDlg::dosave(%this, %filename) {
 	vv_saveState(%filename);
 	Canvas.popDialog(%this);
 	EG_Next.setActive(1);

--- a/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/Vice.mcs
+++ b/Marble Blast Platinum/platinum/data/lbmissions_pq/advanced/Vice.mcs
@@ -186,7 +186,16 @@ function VVNameDlg::discard(%this) {
 }
 
 function VVNameDlg::checkName(%this) {
+	%this.oldName   = VVND_Name.getValue();
+	%this.oldCursor = VVND_Name.getCursorPos();
+
 	VVND_Name.setValue(alphaNum(VVND_Name.getValue()));
+
+	if (VVND_Name.getValue() $= %this.oldName)
+		VVND_Name.setCursorPos(%this.oldCursor);
+	else
+		VVND_Name.setCursorPos(%this.oldCursor - 1);
+
 	VVND_Save.setActive(VVND_Name.getValue() !$= "");
 }
 

--- a/Marble Blast Platinum/platinum/data/missions_pq/advanced/Vice.mcs
+++ b/Marble Blast Platinum/platinum/data/missions_pq/advanced/Vice.mcs
@@ -86,7 +86,7 @@ if (!$Server::Dedicated) {
 				extent = "94 45";
 				minExtent = "8 8";
 				visible = "1";
-				command = "VVNameDlg.dosave();";
+				command = "VVNameDlg.trysave();";
 				helpTag = "0";
 				text = "Save";
 				groupNum = "-1";
@@ -166,13 +166,16 @@ function VVNameDlg::onWake(%this) {
 	%this.checkName();
 }
 
-function VVNameDlg::dosave(%this) {
+function VVNameDlg::trysave(%this) {
 	%filename = "platinum/data/state/vv" @ VVND_Name.getValue() @ ".txt";
 	if (isFile(%filename)) {
-		MessageBoxOk("Error", "That run save already exists.");
+		MessageBoxYesNo("Error", "A saved run with that name already exists. Would you like to overwrite it?", "VVNameDlg.dosave(\"" @ %filename @ "\");");
 		return;
-	}
+	} else
+		%this.dosave(%filename);
+}
 
+function VVNameDlg::dosave(%this, %filename) {
 	vv_saveState(%filename);
 	Canvas.popDialog(%this);
 	EG_Next.setActive(1);

--- a/Marble Blast Platinum/platinum/data/missions_pq/advanced/Vice.mcs
+++ b/Marble Blast Platinum/platinum/data/missions_pq/advanced/Vice.mcs
@@ -186,7 +186,16 @@ function VVNameDlg::discard(%this) {
 }
 
 function VVNameDlg::checkName(%this) {
+	%this.oldName   = VVND_Name.getValue();
+	%this.oldCursor = VVND_Name.getCursorPos();
+
 	VVND_Name.setValue(alphaNum(VVND_Name.getValue()));
+
+	if (VVND_Name.getValue() $= %this.oldName)
+		VVND_Name.setCursorPos(%this.oldCursor);
+	else
+		VVND_Name.setCursorPos(%this.oldCursor - 1);
+
 	VVND_Save.setActive(VVND_Name.getValue() !$= "");
 }
 


### PR DESCRIPTION
* The cursor no longer constantly teleports to the start of the text entry field in the Save Run dialogue
* Rather than entirely disallowing the player from saving runs when one with the same name already exists, they will now be provided with the option to overwrite it instead

CLOSES #177 