### PR TITLE
Competitive Mode tie behaviour

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/modes/competitive.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/modes/competitive.cs
@@ -30,7 +30,9 @@ ModeInfoGroup.add(new ScriptObject(ModeInfo_competitive) {
 	file = "competitive";
 
 	name = "<spush><color:ff0000>Competitive Mode";
-	desc = "<spop><spush><color:ff7777>20 second gem autorespawn timer (decreases to 15/10/5 seconds at 3/2/1 gems remaining). 5 second Mega Marble. Only Ultra Blast pushes other players. No quickspawn. Shared starting point.<spop>";
+	desc = "<spop><spush><color:ff7777>20 second gem autorespawn timer (decreases to 15/10/5 seconds at 3/2/1 gems remaining). 5 second Mega Marble. Only Ultra Blast pushes other players. No quickspawn. Shared starting point. Ties extend the match duration.<spop>";
+	
+	hide = 1;
 });
 
 function ClientMode_competitive::onLoad(%this) {

--- a/Marble Blast Platinum/platinum/server/scripts/modes/competitive.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/modes/competitive.cs
@@ -21,7 +21,77 @@
 //-----------------------------------------------------------------------------
 
 function Mode_competitive::onLoad(%this) {
+    %this.registerCallback("onTimeExpire");
+    %this.registerCallback("onDeactivate");
+    %this.registerCallback("onMissionReset");
+    %this.registerCallback("onMissionEnded");
 	echo("[Mode" SPC %this.name @ "]: Loaded!");
+}
+
+function Mode_competitive::onTimeExpire(%this) {
+    //Check for a tie
+    %max = -1;
+    %tie = false;
+    for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
+        %client = ClientGroup.getObject(%i);
+        %gems = %client.getGemCount();
+        if (%gems > %max) {
+            %max = %gems;
+            %tie = false;
+        } else if (%gems == %max) {
+            %tie = true;
+        }
+    }
+
+    //If there is a tie, extend the match into overtime
+    if (%tie) {
+        Time::stop();
+        %time = MissionInfo.time ? MissionInfo.time : 300000;
+        //Repeat ties: Extend the match by duration / 10
+        if (%this.overtime) {
+            Time::set(%time / 10);
+            Time::start();
+            for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
+                %client = ClientGroup.getObject(%i);
+                %client.addBubbleLine("Tie! The overtime has been extended.");
+                serverPlay2D(SnowGlobeSfx);
+                // %client.playPitchedSound("alarm_timeout");
+            }
+        //First tie: Extend the match by duration / 5
+        } else {
+            Time::set(%time / 5);
+            Time::start();
+            for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
+                %client = ClientGroup.getObject(%i);
+                %client.addBubbleLine("Tie! This match has entered overtime.");
+                serverPlay2D(SnowGlobeSfx);
+                // %client.playPitchedSound("alarm_timeout");
+            }
+            %this.overtime = true;
+        }
+        return false;
+    }
+    
+    %this.overtime = false;
+    return true;
+}
+
+function Mode_competitive::onDeactivate(%this) {
+    //Cancel overtime if deactivated mid-game
+    if (%this.overtime) {
+        Time::stop();
+        Time::set(0);
+        endGameSetup();
+    }
+    %this.overtime = false;
+}
+
+function Mode_competitive::onMissionReset(%this) {
+    %this.overtime = false;
+}
+
+function Mode_competitive::onMissionEnded(%this) {
+    %this.overtime = false;
 }
 
 function isCompetitiveMode() {

--- a/Marble Blast Platinum/platinum/server/scripts/settings.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/settings.cs
@@ -207,7 +207,7 @@ function onPostServerVariableSet(%id, %previous, %value) {
 			activateMode("competitive"); // makes the 'mode' appear consistent (there is no code in competitive.cs)
 			for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
 				%client = ClientGroup.getObject(%i);
-				%client.addBubbleLine("Competitive Mode is on. Gems respawn after 20 seconds, and that time drops if 3 or fewer gems remain. No quickspawn.");
+				%client.addBubbleLine("Competitive Mode is on. Gems respawn after 20 seconds, and that time drops if 3 or less gems remain. No quickspawn.");
 			}
 		} else {
 			deactivateMode("competitive"); // makes the 'mode' appear consistent (there is no code in competitive.cs)


### PR DESCRIPTION
In Competitive Mode, if there is a tie, extend the match into "overtime". The match is extended by 1/5 of its duration (default duration is 05:00.000, so default overtime is 01:00.000).
After overtime has elapsed, if there is still a tie, extend the overtime by 1/10 of the match duration (default 00:30.000).