### PR TITLE
allow sound packs to use pitched sounds and optionally specify pitch mapping overrides

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/audioprofiles.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/audioprofiles.cs
@@ -225,21 +225,51 @@ registerSoundKey("opponentDiamond");
 
 function loadMusicKeys() {
 	%pattern = expandFilename("~/client/audio/*.json");
+	%i = -1;
+	%keyedMusicListIndex = 0;
 	for (%file = findFirstFile(%pattern); %file !$= ""; %file = findNextFile(%pattern)) {
+		%i++;
 		%conts = jsonParse(fread(%file));
 
 		if (!isObject(%conts))
 			continue;
 
-		if (fileBase(%file) $= "default") {
+		%music = fileBase(%file);
+		if (%music $= "default") {
+			$OldKeyDefault = %conts;
 			$KeyDefault = %conts;
 		} else {
-			$Key[fileBase(%file)] = %conts;
+			$OldKey[%music] = %conts;
+			$Key[%music] = %conts;
+			$KeyedMusicList[%keyedMusicListIndex] = %music;
+			%keyedMusicListIndex ++;
 		}
 	}
 }
 
 loadMusicKeys();
+
+function patchMusicKeys(%patches) {
+	for (%i = 0; $KeyedMusicList[%i] !$= ""; %i ++) {
+		%music = $KeyedMusicList[%i];
+		%overrides = %patches.getFieldValue(%music);
+		if (%overrides !$= "") {
+			$Key[%music] = %overrides;
+		}
+	}
+	%defaultOverride = %patches.getFieldValue("default");
+	if (%defaultOverride !$= "") {
+		$KeyDefault = %overrides;
+	}
+}
+
+function resetMusicKeys() {
+	for (%i = 0; $KeyedMusicList[%i] !$= ""; %i ++) {
+		%music = $KeyedMusicList[%i];
+		$Key[%music] = $OldKey[%music];
+	}
+	$KeyDefault = $OldKeyDefault;
+}
 
 function playPitchedSound(%sound, %key) {
 	//Ignore on credits
@@ -472,7 +502,6 @@ function loadAudioPack(%packname) {
 		}
 		return;
 	}
-	%pack.dump();
 	warn("Executed Sound Pack" SPC %pack.name SPC "by" SPC %pack.author @ "...");
 	$Audio::CurrentAudioPack = %pack;
 
@@ -501,6 +530,7 @@ function audioPackReset(%grp) {
 					echo("Substituting modified file" SPC %filename SPC "for original audio file" SPC %oldFilename);
 				%obj.filename = %oldFilename;
 			}
+			resetMusicKeys();
 		default:
 			continue;
 		}
@@ -526,7 +556,7 @@ function audioPackIterate(%grp, %pack) {
 				%found = true;
 			} else {
 				//Pitched sounds?
-				%base = fileBase(filePath(%fileName));
+				%base = fileBase(filePath(%filename));
 
 				if (%pack.sounds.getFieldValue(%base) !$= "") {
 					%found = true;
@@ -537,13 +567,28 @@ function audioPackIterate(%grp, %pack) {
 				if (%obj.oldFilename $= "") {
 					%obj.oldFilename = %filename;
 				}
-				%newfilename = $userMods @ "/data/sound/ap_" @ %pack.identifier @ "/" @ %base @ ".wav";
-				echo("Substituting original file" SPC %filename SPC "for new audio file" SPC %newfilename);
-				if (isFile(%newfilename))
-					%obj.filename = %newfilename;
-				else
-					error("Could not find file" SPC %newfilename);
+				%newFilenameBase = $userMods @ "/data/sound/ap_" @ %pack.identifier @ "/" @ %base;
+				%newFilename = %newFilenameBase @ ".wav";
+				if (isFile(%newFilename)) {
+					echo("Substituting original file" SPC %filename SPC "for new audio file" SPC %newFilename);
+					%obj.filename = %newFilename;
+				} else {
+					// unpitched sound wasn't found; try searching for pitched sound
+					%key = fileBase(%filename);
+					%unpitchedNewFilename = %newFilename;
+					%newFilename = %newFilenameBase @ "/" @ %key @ ".wav";
+					if (isFile(%newFilename)) {
+						echo("Substituting original file" SPC %filename SPC "for new audio file" SPC %newFilename);
+						%obj.filename = %newFilename;
+					} else {
+						error("Could not find file" SPC %unpitchedNewFilename SPC "nor" SPC %newFilename);
+					}
+				}
 			}
+
+			// if pitch map overrides are specified, apply them!
+			if (%pack.pitchMapOverrides !$= "")
+				patchMusicKeys(%pack.pitchMapOverrides);
 		default:
 			continue;
 		}


### PR DESCRIPTION
This PR adds two new features to sound packs:

- Sound packs can now specify overrides for pitched sounds.
  - If a sound is pitched in the default sounds, and the .apk declares it should be replaced, but no unpitched replacement was found, it will look for a directory of pitched replacements.
  - Structure is the same as the default sounds. e.g. `spawn/A.wav`, etc. instead of `spawn.wav`.
- Sound packs can now optionally specify overrides of pitch mappings (`client/audio/*.json`).
  - If the .apk has a key `"pitchMapOverrides"`, and it maps to an object whose keys are music track names (= the file names in `client/audio/*.json`, minus the extension) and whose values are pitch mappings (= the contents of said files), they will override the defaults while the sound pack is active.
  - Overrides for a music track may be omitted, in which case they stick to their defaults.
  - Overrides for a sound within a music track (e.g. trying to override only the `spawn` sound) currently can't be omitted.

I tested this with a sound pack I'm making, which includes pitched sounds (spawn, checkpoint, nest eggs, maybe others) and also needs the ability to remap the key choices per music track. The sound pack works correctly on this branch. Please let me know if you think it's a better idea to include the sound pack in the same PR before merging, or maybe if I should add it in a sub-branch. Otherwise, merging this PR as is would allow me to publish the sound pack elsewhere and have it work for everyone.